### PR TITLE
Revert "Bump lodash from 4.17.15 to 4.17.19 (#35)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5686,9 +5686,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.isequal": {
       "version": "4.5.0",


### PR DESCRIPTION
This reverts commit 25782559b37c0b638040b36c27f857f5ecf4fc50.